### PR TITLE
I added support for direct-byte writes to the display, which required some refactoring.

### DIFF
--- a/TM1637_6D.cpp
+++ b/TM1637_6D.cpp
@@ -36,6 +36,8 @@
 static int8_t TubeTab[] = {0x3f,0x06,0x5b,0x4f,
                            0x66,0x6d,0x7d,0x07,
                            0x7f,0x6f,0x00,0x40};//0~9, 10=blank digit, 11=dash/minus character
+
+static int8_t SegmentToAddressMapping[] = {3,4,5,0,1,2}; // Right to left, segments are 3,4,5,0,1,2						   
 TM1637_6D::TM1637_6D(uint8_t Clk, uint8_t Data)
 {
   Clkpin = Clk;
@@ -95,57 +97,54 @@ void TM1637_6D::stop(void)
   digitalWrite(Clkpin,HIGH);
   digitalWrite(Datapin,HIGH);
 }
+
 //display function.Write to full-screen.
 void TM1637_6D::display(int8_t DispData[], int8_t DispPointData[])
 {
-  int8_t SegData[6];
-  int8_t SegPointData[6];
-  int8_t i;
-  
-  for(i = 0;i < 6;i++)
+  int8_t SegDataMapped[6];
+  coding(DispData, DispPointData, SegDataMapped);
+  displayByte(SegDataMapped);
+}
+
+void TM1637_6D::displayByte(int8_t SegData[])
+{
+  int8_t SegDataMapped[6];
+
+  for(int8_t i=0;i<6;i++)
   {
-    if(DispData[i] > 11 || DispData[i] < 0) DispData[i] = 11;
-  }
+    SegDataMapped[SegmentToAddressMapping[i]] = SegData[i];
+  } 
   
-  SegData[0] = DispData[3];
-  SegData[1] = DispData[4];
-  SegData[2] = DispData[5];
-  SegData[3] = DispData[0];
-  SegData[4] = DispData[1];
-  SegData[5] = DispData[2];
-  
-  SegPointData[0] = DispPointData[3];
-  SegPointData[1] = DispPointData[4];
-  SegPointData[2] = DispPointData[5];
-  SegPointData[3] = DispPointData[0];
-  SegPointData[4] = DispPointData[1];
-  SegPointData[5] = DispPointData[2];
-  
-  coding(SegData, SegPointData);
   start();          //start signal sent to TM1637 from MCU
   writeByte(ADDR_AUTO);//
   stop();           //
   start();          //
   writeByte(Cmd_SetAddr);//
-  for(i=0;i < 6;i ++)
+  for(int i=0;i < 6;i ++)
   {
-    writeByte(SegData[i]);        //
+    writeByte(SegDataMapped[i]);        //
   }
   stop();           //
   start();          //
   writeByte(Cmd_DispCtrl);//
   stop();           //
 }
+
 //******************************************
 void TM1637_6D::display(uint8_t BitAddr,int8_t DispData,int8_t DispPointData)
 {
   int8_t SegData;
   SegData = coding(DispData, DispPointData);
+  displayByte(BitAddr, SegData);
+}
+
+void TM1637_6D::displayByte(uint8_t BitAddr,int8_t SegData)
+{
   start();          //start signal sent to TM1637 from MCU
   writeByte(ADDR_FIXED);//
   stop();           //
   start();          //
-  writeByte(BitAddr|0xc0);//
+  writeByte(SegmentToAddressMapping[BitAddr]|0xc0);//
   writeByte(SegData);//
   stop();            //
   start();          //
@@ -287,21 +286,25 @@ void TM1637_6D::set(uint8_t brightness,uint8_t SetData,uint8_t SetAddr)
   Cmd_DispCtrl = 0x88 + brightness;//Set the brightness and it takes effect the next time it displays.
 }
 
-void TM1637_6D::coding(int8_t DispData[], int8_t DispPointData[])
+void TM1637_6D::coding(int8_t DispData[], int8_t DispPointData[], int8_t SegDataOut[])
 {
   for(uint8_t i = 0;i < 6;i ++)
   {
-    if(DispData[i] == 0x7f)DispData[i] = 0x00 + DispPointData[i];
-    else DispData[i] = TubeTab[DispData[i]] + DispPointData[i];
+	SegDataOut[i] = coding(DispData[i], DispPointData[i]);
   }
 }
 int8_t TM1637_6D::coding(int8_t DispData, int8_t DispPointData)
 {
+  if(DispData > 11 || DispData < 0) DispData = 11;
   if(DispData == 0x7f) DispData = 0x00 + DispPointData;//The bit digital tube off
   else DispData = TubeTab[DispData] + DispPointData;
+  
   return DispData;
 }
+
+
 void TM1637_6D::bitDelay(void)
 {
 	delayMicroseconds(50);
 }
+

--- a/TM1637_6D.cpp
+++ b/TM1637_6D.cpp
@@ -107,10 +107,10 @@ void TM1637_6D::display(int8_t DispData[], int8_t DispPointData[])
 {
   int8_t SegDataMapped[6];
   coding(DispData, DispPointData, SegDataMapped);
-  displayByte(SegDataMapped);
+  displayCodedByte(SegDataMapped);
 }
 
-void TM1637_6D::displayByte(int8_t SegData[])
+void TM1637_6D::displayCodedByte(int8_t SegData[])
 {
   int8_t SegDataMapped[6];
 
@@ -139,10 +139,10 @@ void TM1637_6D::display(uint8_t BitAddr,int8_t DispData,int8_t DispPointData)
 {
   int8_t SegData;
   SegData = coding(DispData, DispPointData);
-  displayByte(BitAddr, SegData);
+  displayCodedByte(BitAddr, SegData);
 }
 
-void TM1637_6D::displayByte(uint8_t BitAddr,int8_t SegData)
+void TM1637_6D::displayCodedByte(uint8_t BitAddr,int8_t SegData)
 {
   start();          //start signal sent to TM1637 from MCU
   writeByte(ADDR_FIXED);//
@@ -168,9 +168,20 @@ void TM1637_6D::displayInteger(int32_t intdisplay, bool leading_zeros)
 {
   int8_t tempListDisp[6];
   int8_t tempListDispPoint[6];
+  int8_t SegDataMapped[6];
+  
+  buildIntegerCodedByteArray(intdisplay, leading_zeros, SegDataMapped);
+  displayCodedByte(SegDataMapped);
+}
 
+void TM1637_6D::buildIntegerCodedByteArray(int32_t intdisplay, bool leading_zeros, int8_t SegDataOut[6])
+{
+  int8_t tempListDisp[6];
+  int8_t tempListDispPoint[6];
+  int8_t SegDataMapped[6];	  
+  
   buildIntegerDispArray(intdisplay, leading_zeros, tempListDisp, tempListDispPoint);
-  display(tempListDisp, tempListDispPoint);
+  coding(tempListDisp, tempListDispPoint, SegDataOut);
 }
 
 void TM1637_6D::buildIntegerDispArray(int32_t intdisplay, bool leading_zeros, int8_t outListDispData[6], int8_t outListDispPointData[6])
@@ -219,15 +230,22 @@ void TM1637_6D::buildIntegerDispArray(int32_t intdisplay, bool leading_zeros, in
   }
 }
 
-
 void TM1637_6D::displayFloat(float floatdisplay)
+{
+  int8_t SegDataMapped[6];
+  buildFloatCodedByteArray(floatdisplay, SegDataMapped);
+  displayCodedByte(SegDataMapped);
+}
+
+void TM1637_6D::buildFloatCodedByteArray(float floatdisplay, int8_t SegDataOut[6])
 {
   int8_t tempListDisp[6];
   int8_t tempListDispPoint[6];
-  
+	  
   buildFloatDispArray(floatdisplay, tempListDisp, tempListDispPoint);
-  display(tempListDisp, tempListDispPoint);
+  coding(tempListDisp, tempListDispPoint, SegDataOut);
 }
+
 
 void TM1637_6D::buildFloatDispArray(float floatdisplay, int8_t outListDispData[6], int8_t outListDispPointData[6])
 {
@@ -279,7 +297,7 @@ void TM1637_6D::buildFloatDispArray(float floatdisplay, int8_t outListDispData[6
 	{
       floatstring =  String(floatdisplay, 6-numberofdigits); // convertering integer to a string
       decimal_point_add = 0;
-	  Serial.println(floatstring.length());
+
       for(i = 0; i < (floatstring.length() - decimal_point_add); i++) 
       {
         

--- a/TM1637_6D.h
+++ b/TM1637_6D.h
@@ -64,9 +64,11 @@ class TM1637_6D
     void display(uint8_t BitAddr,int8_t DispData,int8_t DispPointData);
     void displayByte(int8_t SegData[]);
     void displayByte(uint8_t BitAddr,int8_t SegData);
-	void displayError();
-	void displayInteger(int32_t intdisplay, bool leading_zeros);
-	void displayFloat(float floatdisplay);
+    void displayError();
+    void buildIntegerDispArray(int32_t intdisplay, bool leading_zeros, int8_t outListDispData[6], int8_t outListDispPointData[6]);
+    void displayInteger(int32_t intdisplay, bool leading_zeros);
+    void displayFloat(float floatdisplay);
+    void buildFloatDispArray(float floatdisplay, int8_t outDispData[6], int8_t outDispPointData[6]);
     void clearDisplay(void);
     void set(uint8_t = BRIGHT_TYPICAL,uint8_t = 0x40,uint8_t = 0xc0);//To take effect the next time it displays.
     void coding(int8_t DispData[],int8_t DispPointData[], int8_t SegDataOut[]);

--- a/TM1637_6D.h
+++ b/TM1637_6D.h
@@ -62,12 +62,14 @@ class TM1637_6D
     void stop(void); //send stop bits
     void display(int8_t DispData[],int8_t DispPointData[]);
     void display(uint8_t BitAddr,int8_t DispData,int8_t DispPointData);
+    void displayByte(int8_t SegData[]);
+    void displayByte(uint8_t BitAddr,int8_t SegData);
 	void displayError();
 	void displayInteger(int32_t intdisplay, bool leading_zeros);
 	void displayFloat(float floatdisplay);
     void clearDisplay(void);
     void set(uint8_t = BRIGHT_TYPICAL,uint8_t = 0x40,uint8_t = 0xc0);//To take effect the next time it displays.
-    void coding(int8_t DispData[],int8_t DispPointData[]);
+    void coding(int8_t DispData[],int8_t DispPointData[], int8_t SegDataOut[]);
     int8_t coding(int8_t DispData,int8_t DispPointData);
     void bitDelay(void);
   private:

--- a/TM1637_6D.h
+++ b/TM1637_6D.h
@@ -62,12 +62,14 @@ class TM1637_6D
     void stop(void); //send stop bits
     void display(int8_t DispData[],int8_t DispPointData[]);
     void display(uint8_t BitAddr,int8_t DispData,int8_t DispPointData);
-    void displayByte(int8_t SegData[]);
-    void displayByte(uint8_t BitAddr,int8_t SegData);
+    void displayCodedByte(int8_t SegData[]);
+    void displayCodedByte(uint8_t BitAddr,int8_t SegData);
     void displayError();
     void buildIntegerDispArray(int32_t intdisplay, bool leading_zeros, int8_t outListDispData[6], int8_t outListDispPointData[6]);
     void displayInteger(int32_t intdisplay, bool leading_zeros);
+	void buildIntegerCodedByteArray(int32_t intdisplay, bool leading_zeros, int8_t SegDataOut[6]);
     void displayFloat(float floatdisplay);
+	void buildFloatCodedByteArray(float floatdisplay, int8_t SegDataOut[6]);
     void buildFloatDispArray(float floatdisplay, int8_t outDispData[6], int8_t outDispPointData[6]);
     void clearDisplay(void);
     void set(uint8_t = BRIGHT_TYPICAL,uint8_t = 0x40,uint8_t = 0xc0);//To take effect the next time it displays.

--- a/examples/MultiFunctionDisplay/MultiFunctionDisplay.ino
+++ b/examples/MultiFunctionDisplay/MultiFunctionDisplay.ino
@@ -25,8 +25,8 @@
  
 #include "TM1637_6D.h"
 
-#define CLK 3 //pins definitions for TM1637 and can be changed to other ports
-#define DIO 2
+#define CLK 6 //pins definitions for TM1637 and can be changed to other ports
+#define DIO 5
 
 TM1637_6D tm1637_6D(CLK,DIO);
 
@@ -60,12 +60,12 @@ void loop()
     delay(500);
   }
  
-  tm1637_6D.displayByte(ListDispByte);
+  tm1637_6D.displayCodedByte(ListDispByte);
   delay(500);
 
   for(int i=0;i<6;i++)
   {
-    tm1637_6D.displayByte(i,0b11001001);
+    tm1637_6D.displayCodedByte(i,0b11001001);
     delay(500);
   }
   tm1637_6D.clearDisplay();

--- a/examples/MultiFunctionDisplay/MultiFunctionDisplay.ino
+++ b/examples/MultiFunctionDisplay/MultiFunctionDisplay.ino
@@ -1,0 +1,74 @@
+/*
+ * Example for 6-digit TM1637 based segment Display
+ * The number of milliseconds after start will be displayed on the 6-digit screen
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+ 
+#include "TM1637_6D.h"
+
+#define CLK 3 //pins definitions for TM1637 and can be changed to other ports
+#define DIO 2
+
+TM1637_6D tm1637_6D(CLK,DIO);
+
+void setup()
+{
+  tm1637_6D.init();
+  // You can set the brightness level from 0(darkest) till 7(brightest) or use one
+  // of the predefined brightness levels below
+  tm1637_6D.set(BRIGHT_TYPICAL);//BRIGHT_TYPICAL = 2,BRIGHT_DARKEST = 0,BRIGHTEST = 7;
+  Serial.begin(9600);
+}
+void loop()
+{
+  // Array for displaying digits, the first number in the array will be displayed on the right
+  int8_t ListDisp[6] = {6,5,4,3,2,1};
+  
+  // Array for displaying points, the first point in the array will be displayed on the right
+  int8_t ListDispPoint[6] = {POINT_OFF,POINT_ON,POINT_OFF,POINT_OFF,POINT_OFF,POINT_OFF};
+
+  int8_t ListDispByte[6] = {0b00001111,0b00001001,0b00001001,0b00001001,0b00001001,0b00111001};
+
+  tm1637_6D.displayFloat(1.23456);
+  delay(1000);
+  tm1637_6D.displayInteger(123456,0);
+  delay(1000);
+  tm1637_6D.display(ListDisp, ListDispPoint);
+  delay(1000);
+  for(int i=0;i<6;i++)
+  {
+    tm1637_6D.display(i,11,POINT_ON);
+    delay(500);
+  }
+ 
+  tm1637_6D.displayByte(ListDispByte);
+  delay(500);
+
+  for(int i=0;i<6;i++)
+  {
+    tm1637_6D.displayByte(i,0b11001001);
+    delay(500);
+  }
+  tm1637_6D.clearDisplay();
+
+    
+}


### PR DESCRIPTION
One of the changes is a breaking change - Your original method:

display(uint8_t BitAddr,int8_t DispData,int8_t DispPointData)

...would not map the BitAddr, so a BitAddr of 0 would affect the 3rd from the left digit (I think?). I modified it so that it will map, so BitAddr of 0 now affects the same digit as the 0 position of an array, which is the right-most digit.

I did a fair bit of refactoring to make reusable functions. I don't think there should be any significant performance penalty to this, as I believe the compiler will optimize it well but I am not an expert on that.